### PR TITLE
Give more examples for setting up webhook

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-useGitHubHooks.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-useGitHubHooks.html
@@ -5,6 +5,6 @@
 	admin rights to the specified repository.<br/>
 	If you want to create a hook manually set it for event types:
 		<code>issue_comment</code>,	<code>pull_request</code>
-	and url <code>http://yourserver.com/jenkins/ghprbhook/</code>.<br/>
+	and url <code>< your jenkins server url >/ghprbhook/</code>, e.g. https://jenkins.yourcompany.com/ghprbhook/ or https://yourcompany.com/jenkins/ghprbhook/<br/>
 	Your Jenkins server must be accessible from internet.
 </div>


### PR DESCRIPTION
I ran into problems because I thought the path to the webhook was `/jenkins/ghprbhook/` when in fact the path is just `/ghprbhook/`.  The example in the documentation assumed users were running jenkins at `/jenkins` on their server.  This PR clarifies the documentation and provides examples of two common types of configurations.  